### PR TITLE
consistent naming of output folder & schema

### DIFF
--- a/dgen_os/python/data_functions.py
+++ b/dgen_os/python/data_functions.py
@@ -139,8 +139,6 @@ def create_output_schema(pg_conn_string, role, suffix, scenario_list, source_sch
     """
 
     inputs = locals().copy()
-    suffix = utilfunc.get_formatted_time()
-    suffix_microsecond = datetime.now().strftime('%f')
     logger.info('Creating output schema based on {source_schema}'.format(**inputs))
 
     con, cur = utilfunc.make_con(pg_conn_string, role)
@@ -156,7 +154,7 @@ def create_output_schema(pg_conn_string, role, suffix, scenario_list, source_sch
 
     scen_suffix = os.path.split(scenario_list[0])[1].split('_')[2].rstrip('.xlsm')
 
-    dest_schema = 'diffusion_results_{}'.format(suffix+suffix_microsecond+'_'+scen_suffix)
+    dest_schema = 'diffusion_results_{0}_{1}'.format(suffix, scen_suffix)
     inputs['dest_schema'] = dest_schema
 
     sql = '''SELECT diffusion_shared.clone_schema('{source_schema}', '{dest_schema}', '{role}', {include_data});'''.format(**inputs)

--- a/dgen_os/python/settings.py
+++ b/dgen_os/python/settings.py
@@ -482,7 +482,7 @@ def init_model_settings():
     model_settings.add_config(config)
     model_settings.set('model_init', utilfunc.get_epoch_time())
     model_settings.set('cdate', utilfunc.get_formatted_time())
-    model_settings.set('out_dir', datfunc.make_output_directory_path(model_settings.cdate))
+    model_settings.set('out_dir', datfunc.make_output_directory_path(model_settings.cdate[:-6]))
     model_settings.set('input_data_dir', '{}/input_data'.format(os.path.dirname(os.getcwd())))
     model_settings.set('input_agent_dir', '{}/input_agents'.format(os.path.dirname(os.getcwd())))
     model_settings.set('input_scenarios', datfunc.get_input_scenarios())

--- a/dgen_os/python/utility_functions.py
+++ b/dgen_os/python/utility_functions.py
@@ -249,6 +249,6 @@ def get_epoch_time():
 
 def get_formatted_time():
 
-    formatted_time = time.strftime('%Y%m%d_%H%M%S')
+    formatted_time = time.strftime('%Y%m%d_%H%M%S') + datetime.datetime.now().strftime('%f')
 
     return formatted_time


### PR DESCRIPTION
Fixes #21 by creating the date/time string used for naming once in utility_functions.get_formatted_time and reusing it in settings.init_model_settings and again in data_functions.create_output_schema.