### PR TITLE
Targets env updates, Pandas warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ After cloning this repository and installing (and running) Docker as well as Ana
 ```$ conda env create -f dg3n.yml```
 
 - This will create the conda environment needed to run the dgen model.
+- The dgen model is optimized for Python v3 and above. Run ```$ conda list ``` to verify you have this version.
 
 2. This command will create a container with PostgreSQL initialized.
 

--- a/dgen_os/python/dg3n.yml
+++ b/dgen_os/python/dg3n.yml
@@ -5,7 +5,6 @@ channels:
   - anaconda
   - nrel
 dependencies:
-  - python
   - colorama
   - colorlog
   - requests

--- a/dgen_os/python/dg3n.yml
+++ b/dgen_os/python/dg3n.yml
@@ -5,17 +5,17 @@ channels:
   - anaconda
   - nrel
 dependencies:
-  - python=3
+  - python
   - colorama
   - colorlog
   - requests
   - matplotlib
   - numpy
   - openpyxl
-  - pandas=1.1.5
+  - pandas
   - pyarrow
   - psutil
-  - psycopg2
+  - psycopg2=2.8.6
   - scipy
   - spyder
   - sqlalchemy

--- a/dgen_os/python/dg3n.yml
+++ b/dgen_os/python/dg3n.yml
@@ -14,7 +14,7 @@ dependencies:
   - pandas
   - pyarrow
   - psutil
-  - psycopg2=2.8.6
+  - psycopg2
   - scipy
   - spyder
   - sqlalchemy

--- a/dgen_os/python/dgen_model.py
+++ b/dgen_os/python/dgen_model.py
@@ -25,7 +25,14 @@ import PySAM
 #==============================================================================
 pd.set_option('mode.chained_assignment', None)
 #==============================================================================
+# Suppress warnings from Pandas
+'''Should be re-visted if/when Pandas supports psycopg2 or when work can be done 
+to update code to use SQLalchemy instead'''
 
+import warnings
+
+warnings.simplefilter("ignore")
+#============================================================================== 
 
 def main(mode = None, resume_year = None, endyear = None, ReEDS_inputs = None):
     """

--- a/dgen_os/python/input_data_functions.py
+++ b/dgen_os/python/input_data_functions.py
@@ -319,7 +319,7 @@ def deprec_schedule(df):
 
     for year in missing_years:
         last_entry['year'] = year
-        df = df.append(last_entry)
+        df = pd.concat([df,last_entry], ignore_index=True, sort=False)
 
 
     return df.loc[:,['year','sector_abbr','deprec_sch']]


### PR DESCRIPTION
Updates:
- Pins psycopg2 version and unpins Python and Pandas version in `dg3n.yml`
- Suppresses Pandas warning in `dgen_model.py` (includes note about future work to fully resolve these warnings)
- Removes use of `df.append` in favor of `pd.concat` in `input_data_functions.py` due to depreciation warning