### PR TITLE
Addresses Psycopg2 issue

### DIFF
--- a/dgen_os/python/excel/excel_objects.py
+++ b/dgen_os/python/excel/excel_objects.py
@@ -201,8 +201,9 @@ class FancyNamedRange(object):
             cursor.execute(sql)
             connection.commit()
  
-        sql = '{}.{}'.format(schema, table)
-        cursor.copy_from(s, sql, sep = ',', null = '')
+        f = "COPY {}.{} FROM STDIN WITH DELIMITER AS ',' NULL AS ''".format(schema, table)
+
+        cursor.copy_expert(f, s)
         connection.commit()    
         
         # release the string io object


### PR DESCRIPTION
Closes #30 #25 
Updates code to use `copy_expert` instead of `copy_from` to resolve error from Psycopg2 v2.9+

Note:
If merged first, will need to update `dg3n.yml` file changes in #29 to unpin version. If merged after, will need to update yml in this PR.