### PR TITLE
Enable Multi-Core Processing Across All Operating Systems

### DIFF
--- a/dgen_os/python/agents.py
+++ b/dgen_os/python/agents.py
@@ -283,10 +283,7 @@ class Agents(object):
             apply_func = partial(func, **kwargs)
             results_df = self.df.apply(apply_func, axis=1)
         else:
-            if 'ix' not in os.name:
-                EXECUTOR = cf.ThreadPoolExecutor
-            else:
-                EXECUTOR = cf.ProcessPoolExecutor
+            EXECUTOR = cf.ProcessPoolExecutor
 
             futures = []
             with EXECUTOR(max_workers=cores) as executor:
@@ -329,10 +326,7 @@ class Agents(object):
             apply_func = partial(func, **kwargs)
             results_df = self.df.apply(apply_func, axis=1)
         else:
-            if 'ix' not in os.name:
-                EXECUTOR = cf.ThreadPoolExecutor
-            else:
-                EXECUTOR = cf.ProcessPoolExecutor
+            EXECUTOR = cf.ProcessPoolExecutor
 
             logger.info('Number of Workers inside chunk_on_row is {}'.format(cores)) 
             futures = []

--- a/dgen_os/python/dgen_model.py
+++ b/dgen_os/python/dgen_model.py
@@ -221,10 +221,7 @@ def main(mode = None, resume_year = None, endyear = None, ReEDS_inputs = None):
                     # Apply host-owned financial parameters
                     solar_agents.on_frame(agent_mutation.elec.apply_financial_params, [financing_terms, itc_options, inflation_rate])
 
-                    if 'ix' not in os.name: 
-                        cores = None
-                    else:
-                        cores = model_settings.local_cores
+                    cores = model_settings.local_cores
 
                     # Apply state incentives
                     solar_agents.on_frame(agent_mutation.elec.apply_state_incentives, [state_incentives, year, model_settings.start_year, state_capacity_by_year])


### PR DESCRIPTION
I noticed that when running the dGen model on a Windows 10 device, specifying multiple cores in `config.py` did not result in multi-core utilization; only one CPU core was being used. Upon investigating, I found several checks for `if 'ix' not in os.name:` in `dgen_model.py` and `agents.py`. These checks set the number of cores to `None` and used `cf.ThreadPoolExecutor` for non-'ix' operating systems, while `cf.ProcessPoolExecutor` was used for 'ix' operating systems.

To address this, I made the following changes:

- Removed the `if` clauses that checked for the OS name.
- Ensured that the number of cores specified in `config.py` is respected.
- Set `cf.ProcessPoolExecutor` as the default executor regardless of the operating system.

These changes have significantly improved performance in my tests. The model now spawns processes equal to the number of cores specified in `config.py`, resulting in computation times that are approximately divided by the number of cores used.

Please review these changes and consider merging them if they do not cause any issues.