### PR TITLE
Resolve SQL Lock Issues in `df_to_psql` Function

### DIFF
--- a/dgen_os/python/input_data_functions.py
+++ b/dgen_os/python/input_data_functions.py
@@ -132,8 +132,9 @@ def df_to_psql(df, engine, schema, owner, name, if_exists='replace', append_tran
     if if_exists == 'append':
         fields = [i.lower() for i in get_psql_table_fields(engine, schema, name)]
         for f in list(set(df.columns.values) - set(fields)):
-            sql = "ALTER TABLE {}.{} ADD COLUMN {} {}".format(schema, name, f, sql_type[f])
-            conn.execute(sql)
+            with conn.begin():
+                sql = "ALTER TABLE {}.{} ADD COLUMN {} {}".format(schema, name, f, sql_type[f])
+                conn.execute(sql)
         
     df.to_sql(name, engine, schema=schema, index=False, dtype=d_types, if_exists=if_exists)
     sql = 'ALTER TABLE {}."{}" OWNER to "{}"'.format(schema, name, owner)


### PR DESCRIPTION
I encountered issues with SQL locks (observed in pgAdmin) that were preventing the model from completing its run. The locks were occurring specifically in the `df_to_psql` function within `input_data_functions.py`. After reviewing the SQLAlchemy documentation, I found that using a "begin once" block could help mitigate this issue. Specifically, I referred to the documentation [here](https://docs.sqlalchemy.org/en/20/core/connections.html).

To address the problem, I made the following change:
- Added `with conn.begin:` to the SQL loop in the `df_to_psql` function within `input_data_functions.py`.

This change ensures that each transaction is properly managed within the `df_to_psql` function, which has resolved the SQL lock issues in my tests. The model now completes its run without encountering lock-related interruptions.

Thank you for reviewing this request.