### PR TITLE
called con.close() to free sys resources

### DIFF
--- a/dgen_os/python/financial_functions.py
+++ b/dgen_os/python/financial_functions.py
@@ -280,6 +280,7 @@ def calc_system_size_and_performance(agent, sectors, rate_switch_table=None):
     norm_scaled_pv_cf_profiles_df = agent_mutation.elec.get_and_apply_normalized_hourly_resource_solar(con, agent)
     pv['generation_hourly'] = pd.Series(norm_scaled_pv_cf_profiles_df['solar_cf_profile'].iloc[0]) /  1e6
     del norm_scaled_pv_cf_profiles_df
+    con.close()
     
     agent.loc['naep'] = float(np.sum(pv['generation_hourly']))
 


### PR DESCRIPTION
Updating financial_functions.py to close psycopg2 connection object after used to get normalized load profiles and agent load profiles.